### PR TITLE
Allow uninstalling or reinstalling based on variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ ffmpeg_executable_path: "/usr/bin/ffmpeg"
 
 # The final path of ffprobe executable
 ffprobe_executable_path: "/usr/bin/ffprobe"
+
+# Whether to uninstall ffmpeg and ffprobe
+uninstall_ffmpeg: 'false'
+
+# Whether to reinstall ffmpeg and ffprobe when they exist
+reinstall_ffmpeg: 'false'
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,9 @@ ffmpeg_executable_path: /usr/bin/ffmpeg
 
 # The final path of ffprobe executable
 ffprobe_executable_path: /usr/bin/ffprobe
+
+# Whether to uninstall ffmpeg and ffprobe
+uninstall_ffmpeg: 'false'
+
+# Whether to reinstall ffmpeg and ffprobe when they exist
+reinstall_ffmpeg: 'false'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,56 @@
+---
+- name: Check if ffmpeg is already installed
+  stat:
+    path: "{{ ffmpeg_executable_path }}"
+  register: ffmpeg_bin
+
+- name: Check if ffprobe is already installed
+  stat:
+    path: "{{ ffprobe_executable_path }}"
+  register: ffprobe_bin
+
+- name: Create a temp directory
+  file:
+    path: "{{ ffmpeg_temp_path }}"
+    state: directory
+  when: (not ffmpeg_bin.stat.exists) or
+        (not ffprobe_bin.stat.exists)
+
+- name: Download from custom source
+  get_url:
+    url: https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz
+    dest: "{{ ffmpeg_temp_path }}/ffmpeg-git-amd64-static.tar.xz"
+  when: (not ffmpeg_bin.stat.exists) or
+        (not ffprobe_bin.stat.exists)
+
+- name: Unarchive to temp directory
+  shell: tar xf {{ ffmpeg_temp_path }}/ffmpeg-git-amd64-static.tar.xz --strip-components=1 -C {{ ffmpeg_temp_path }}/
+  when: (not ffmpeg_bin.stat.exists) or
+        (not ffprobe_bin.stat.exists)
+
+- name: Move ffmpeg to executables directory
+  command: mv {{ ffmpeg_temp_path }}/ffmpeg {{ ffmpeg_executable_path }}
+  args:
+    creates: "{{ ffmpeg_executable_path }}"
+
+- name: Move ffprobe to executables directory
+  command: mv {{ ffmpeg_temp_path }}/ffprobe {{ ffprobe_executable_path }}
+  args:
+    creates: "{{ ffprobe_executable_path }}"
+
+- name: Make ffmpeg executable by all users
+  file:
+    path: "{{ ffmpeg_executable_path }}"
+    mode: 0755
+  when: not ffmpeg_bin.stat.exists
+
+- name: Make ffprobe executable by all users
+  file:
+    path: "{{ ffprobe_executable_path }}"
+    mode: 0755
+  when: not ffprobe_bin.stat.exists
+
+- name: Delete temp directory
+  file:
+    path: "{{ ffmpeg_temp_path }}"
+    state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,56 +1,6 @@
----
-- name: Check if ffmpeg is already installed
-  stat:
-    path: "{{ ffmpeg_executable_path }}"
-  register: ffmpeg_bin
+- include: uninstall.yml
+  when: uninstall_ffmpeg == 'true' or reinstall_ffmpeg == 'true'
 
-- name: Check if ffprobe is already installed
-  stat:
-    path: "{{ ffprobe_executable_path }}"
-  register: ffprobe_bin
+- include: install.yml
+  when: uninstall_ffmpeg != 'true'
 
-- name: Create a temp directory
-  file:
-    path: "{{ ffmpeg_temp_path }}"
-    state: directory
-  when: (not ffmpeg_bin.stat.exists) or
-        (not ffprobe_bin.stat.exists)
-
-- name: Download from custom source
-  get_url:
-    url: https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz
-    dest: "{{ ffmpeg_temp_path }}/ffmpeg-git-amd64-static.tar.xz"
-  when: (not ffmpeg_bin.stat.exists) or
-        (not ffprobe_bin.stat.exists)
-
-- name: Unarchive to temp directory
-  shell: tar xf {{ ffmpeg_temp_path }}/ffmpeg-git-amd64-static.tar.xz --strip-components=1 -C {{ ffmpeg_temp_path }}/
-  when: (not ffmpeg_bin.stat.exists) or
-        (not ffprobe_bin.stat.exists)
-
-- name: Move ffmpeg to executables directory
-  command: mv {{ ffmpeg_temp_path }}/ffmpeg {{ ffmpeg_executable_path }}
-  args:
-    creates: "{{ ffmpeg_executable_path }}"
-
-- name: Move ffprobe to executables directory
-  command: mv {{ ffmpeg_temp_path }}/ffprobe {{ ffprobe_executable_path }}
-  args:
-    creates: "{{ ffprobe_executable_path }}"
-
-- name: Make ffmpeg executable by all users
-  file:
-    path: "{{ ffmpeg_executable_path }}"
-    mode: 0755
-  when: not ffmpeg_bin.stat.exists
-
-- name: Make ffprobe executable by all users
-  file:
-    path: "{{ ffprobe_executable_path }}"
-    mode: 0755
-  when: not ffprobe_bin.stat.exists
-
-- name: Delete temp directory
-  file:
-    path: "{{ ffmpeg_temp_path }}"
-    state: absent

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,0 +1,7 @@
+- name: Uninstall old ffmpeg and ffprobe
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ ffmpeg_executable_path }}"
+    - "{{ ffprobe_executable_path }}"


### PR DESCRIPTION
First of all, thanks a lot for your work on this! Hopefully this is a useful contribution to this galaxy role.

This is a backwards compatible change - behaviour remains unchanged when it's
run with default variables. 

However this allows uninstalling or reinstalling
ffmpeg and ffprobe when variables `reinstall_ffmpeg` or `uninstall_ffmpeg` are set
to 'true' either in `vars` section of the playbook or via extra vars e.g.
`ansible <playbook_name> --extra-vars "reinstall_ffmpeg=true"`